### PR TITLE
make y rotation packing/unpacking use u16

### DIFF
--- a/src/client/replicate.luau
+++ b/src/client/replicate.luau
@@ -100,34 +100,17 @@ local function UnpackSnapshotData(
 	local x = buffer.readf32(buff, offset + 4)
 	local y = buffer.readf32(buff, offset + 8)
 	local z = buffer.readf32(buff, offset + 12)
-	value.cframe = {}
-	value.cframe.Position = Vector3.new(x, y, z)
 
-	local encoded = buffer.readu16(buff, offset + 16)
+	local rotationY = buffer.readu16(buff, offset + 16)
+	local remappedRotationY = math.map(rotationY, 0, 2^16 - 1, -math.pi, math.pi)
+
+	value.cframe = {
+		Position = Vector3.new(x, y, z),
+		RotationY = remappedRotationY
+	}
+
 	local id, newOffset = ReadVlqRaw(buff, offset + 18)
-	local mantissaExponent = encoded % 0x8000
 	value.id = id
-
-	if mantissaExponent == 0b0_11111_0000000000 then
-		value.cframe.RotationY = if encoded // 0x8000 == 1 then -math.huge else math.huge
-	elseif mantissaExponent == 0b1_11111_0000000000 then
-		value.cframe.RotationY = 0 / 0
-	elseif mantissaExponent == 0b0_00000_0000000000 then
-		value.cframe.RotationY = 0
-	else
-		local mantissa = mantissaExponent % 0x400
-		local exponent = mantissaExponent // 0x400
-		local fraction
-
-		if exponent == 0 then
-			fraction = mantissa / 0x400
-		else
-			fraction = mantissa / 0x800 + 0.5
-		end
-
-		local result = math.ldexp(fraction, exponent - 14)
-		value.cframe.RotationY = if encoded // 0x8000 == 1 then -result else result
-	end
 
 	return value, newOffset
 end
@@ -144,7 +127,8 @@ local function PackSnapshotData(
 	buffer.writef32(buff, offset + 8, cframe.Position.Y)
 	buffer.writef32(buff, offset + 12, cframe.Position.Z)
 
-	buffer.writeu16(buff, offset + 16, PackF16(cframe.RotationY))
+	local mappedRotationY = math.map(cframe.RotationY, -math.pi, math.pi, 0, 2^16 - 1)
+	buffer.writeu16(buff, offset + 16, mappedRotationY)
 end
 
 local function Flush()

--- a/src/server/replicate.luau
+++ b/src/server/replicate.luau
@@ -102,7 +102,8 @@ local function PackSnapshotData(
 	buffer.writef32(buff, offset + 8, cframe.Position.Y)
 	buffer.writef32(buff, offset + 12, cframe.Position.Z)
 
-	buffer.writeu16(buff, offset + 16, PackF16(cframe.RotationY))
+	local mappedRotationY = math.map(cframe.RotationY, -math.pi, math.pi, 0, 2^16 - 1)
+	buffer.writeu16(buff, offset + 16, mappedRotationY)
 	return WriteVlqRaw(buff, offset + 18, id)
 end
 
@@ -116,32 +117,14 @@ local function UnpackSnapshotData(
 	local x = buffer.readf32(buff, offset + 4)
 	local y = buffer.readf32(buff, offset + 8)
 	local z = buffer.readf32(buff, offset + 12)
-	value.cframe = {}
-	value.cframe.Position = Vector3.new(x, y, z)
+	
+	local rotationY = buffer.readu16(buff, offset + 16)
+	local remappedRotationY = math.map(rotationY, 0, 2^16 - 1, -math.pi, math.pi)
 
-	local encoded = buffer.readu16(buff, offset + 16)
-	local mantissaExponent = encoded % 0x8000
-
-	if mantissaExponent == 0b0_11111_0000000000 then
-		value.cframe.RotationY = if encoded // 0x8000 == 1 then -math.huge else math.huge
-	elseif mantissaExponent == 0b1_11111_0000000000 then
-		value.cframe.RotationY = 0 / 0
-	elseif mantissaExponent == 0b0_00000_0000000000 then
-		value.cframe.RotationY = 0
-	else
-		local mantissa = mantissaExponent % 0x400
-		local exponent = mantissaExponent // 0x400
-		local fraction
-
-		if exponent == 0 then
-			fraction = mantissa / 0x400
-		else
-			fraction = mantissa / 0x800 + 0.5
-		end
-
-		local result = math.ldexp(fraction, exponent - 14)
-		value.cframe.RotationY = if encoded // 0x8000 == 1 then -result else result
-	end
+	value.cframe = {
+		Position = Vector3.new(x, y, z),
+		RotationY = remappedRotationY
+	}
 
 	return value
 end


### PR DESCRIPTION
Hi! I saw that you were using f16 for the y rotation when packing/unpacking snapshots. However since this is code that has to be executed very often I believe u16s with some remapping are a better fit, since just writing/reading and remapping is obviously going to be faster than the math required to convert to/from a f16. With a u16 that makes full use of the range your precision is going to be ~0.0055 degrees which is plenty for an accurate visual.
I haven't had a proper chance to test this so please make sure my code doesn't break anything in unexpected ways.