### PR TITLE
Client Sided Npcs

### DIFF
--- a/src/Client/InterpolationBuffer.luau
+++ b/src/Client/InterpolationBuffer.luau
@@ -58,9 +58,23 @@ return function(minBuffer: number, maxBuffer: number, alpha: number)
 		return buffer
 	end
 
+	local function Remove(id: number)
+		playerLatencies[id] = nil
+		RenderCache.Remove(id)
+	end
+
+	local function Clear(id)
+		playerLatencies[id] = nil
+		RenderCache.Remove(id)
+		RenderCache.Add(id)
+	end
+
 	return {
 		RegisterPacket = RegisterPacket,
 		GetBuffer = GetBuffer,
+		Remove = Remove,
 		PlayerLatencies = playerLatencies,
+		Clear = Clear,
+		
 	}
 end

--- a/src/Client/RenderCache.luau
+++ b/src/Client/RenderCache.luau
@@ -106,7 +106,7 @@ local function GetEstimatedServerTime(id: number): number
 		return 0
 	end
 	return info.lastClockAt + (os.clock() - info.lastClockDuration)
-end
+end 
 
 local function Add(id: number, isNPC: boolean?, npcType: string?)
 	if not clientClockInfo[id] then

--- a/src/Client/Replicate.luau
+++ b/src/Client/Replicate.luau
@@ -15,9 +15,10 @@ local CUSTOM_CHARACTERS = Config.ENABLE_CUSTOM_CHARACTERS
 local MAX_UNRELIABLE_BYTES = 900
 local SNAPSHOT_SIZE = if Config.SEND_FULL_ROTATION then 24 else 20
 local HEADER_SIZE = 2
+local MAX_AWAITING_TIME = 2 --seconds
 local MAX_BATCH = (MAX_UNRELIABLE_BYTES - HEADER_SIZE) // SNAPSHOT_SIZE
 
-local outgoingSnapshots = {} :: { { timestamp: number, cframe: CFrame } }
+local outgoingSnapshots = {} :: { { timestamp: number, cframe: CFrame, id: number } }
 
 local ClientReplicateCFrame: UnreliableRemoteEvent = ReplicatedStorage:WaitForChild("ClientReplicateCFrame") :: any
 local ServerReplicateCFrame: UnreliableRemoteEvent = ReplicatedStorage:WaitForChild("ServerReplicateCFrame") :: any
@@ -27,6 +28,7 @@ local idMap = {} :: {
 		snapshot: Snapshots.Snapshot<CFrame>,
 		character: Model?,
 		lastCFrame: CFrame?,
+		lastSent: number?,
 
 		isNPC: boolean?,
 		npcType: string?,
@@ -35,6 +37,14 @@ local idMap = {} :: {
 		_characterAdded: RBXScriptConnection?,
 	},
 }
+
+local awaitingSnapshots = {} :: { [number]: { timestamp: number, cframe: CFrame, clock: number} }
+
+local clientOwnerShip: {}
+task.defer(function()
+	local NpcRegistry = (require)(script.Parent.Parent.Shared.NpcRegistry)
+	clientOwnerShip = NpcRegistry._ClientOwners
+end)
 
 local playerToId = {} :: { [Player]: number }
 local player = Players.LocalPlayer
@@ -105,7 +115,7 @@ local function UnpackSnapshotData(buff: buffer, offset: number): any
 	return value
 end
 
-local function PackSnapshotData(buff: buffer, offset: number, timestamp: number, cframe: CFrame)
+local function PackSnapshotData(buff: buffer, offset: number, timestamp: number, cframe: CFrame,id : number)
 	buffer.writef32(buff, offset + 0, timestamp)
 	buffer.writef32(buff, offset + 4, cframe.Position.X)
 	buffer.writef32(buff, offset + 8, cframe.Position.Y)
@@ -121,10 +131,12 @@ local function PackSnapshotData(buff: buffer, offset: number, timestamp: number,
 		buffer.writeu16(buff, offset + 16, mappedX)
 		buffer.writeu16(buff, offset + 18, mappedY)
 		buffer.writeu16(buff, offset + 20, mappedZ)
+		buffer.writeu16(buff, offset + 22, id)
 	else
 		local networkable = Networkables.MakeYawNetworkable(cframe)
 		local mappedRotationY = math.map(networkable.RotationY, -math.pi, math.pi, 0, 2 ^ 16 - 1)
 		buffer.writeu16(buff, offset + 16, mappedRotationY)
+		buffer.writeu16(buff, offset + 18, id)
 	end
 end
 
@@ -139,7 +151,7 @@ local function Flush()
 	for i = 1, count do
 		local snapshot = outgoingSnapshots[#outgoingSnapshots]
 		outgoingSnapshots[#outgoingSnapshots] = nil
-		PackSnapshotData(snapshotBuffer, offset, snapshot.timestamp, snapshot.cframe)
+		PackSnapshotData(snapshotBuffer, offset, snapshot.timestamp, snapshot.cframe,snapshot.id)
 		offset += SNAPSHOT_SIZE
 	end
 
@@ -161,6 +173,11 @@ local function RegisterClientNPC(id: number, model: Model, npcType: string?)
 		}
 		RenderCache.Add(id, true, npcType)
 	end
+	
+	if clientOwnerShip[id] and clientOwnerShip[id] ~= true then
+		idMap[id].snapshot:Push(os.clock(), clientOwnerShip[id])
+		clientOwnerShip[id] = true
+	end
 
 	idMap[id].character = model
 
@@ -175,7 +192,7 @@ local function UnregisterNPC(id: number): Model?
 		return nil
 	end
 
-	RenderCache.Remove(id)
+	bufferTracker.Remove(id)
 
 	idMap[id] = nil
 	return data.character
@@ -315,6 +332,13 @@ ServerReplicateCFrame.OnClientEvent:Connect(function(snapshotBuffer)
 		offset += SNAPSHOT_SIZE
 
 		local id = snapshot.id
+		if not idMap[id] then
+			if awaitingSnapshots[id] and awaitingSnapshots[id].timestamp > snapshot.timestamp then
+				continue
+			end
+			awaitingSnapshots[id] = { timestamp = snapshot.timestamp, cframe = snapshot.cframe, clock = os.clock() }
+			continue
+		end
 		cframes[id] = snapshot.cframe
 		timestamps[id] = snapshot.timestamp
 	end
@@ -344,9 +368,22 @@ RunService.PreRender:Connect(function(deltaTime: number)
 		local targetCFrame = data.snapshot:GetAt(targetRenderTime)
 		debug.profileend()
 
+		if clientOwnerShip[id] and (data::any).initializedCFrame then
+			continue
+		end
+		if clientOwnerShip[id]  then
+			local latest = data.snapshot:GetLatest()
+			if not latest then
+				continue
+			end
+			
+			targetCFrame = latest.value
+			;(data::any).initializedCFrame = true
+		end
+
 		debug.profilebegin("Prepare CFrame")
 		if targetCFrame then
-			data.lastCFrame = targetCFrame
+			--data.lastCFrame = targetCFrame
 
 			-- make sure it isn't welded to anything else (e.g. being carried)
 
@@ -359,8 +396,50 @@ RunService.PreRender:Connect(function(deltaTime: number)
 	debug.profileend()
 end)
 
+local function checkCFrameChanges(cf: CFrame, last: CFrame)
+	local changed = (last.Position - cf.Position).Magnitude >= 0.05 or not last.Rotation:FuzzyEq(cf.Rotation, 0.0001)
+	return changed
+end
+
 local lastSentCFrame = CFrame.identity
-RunService.PostSimulation:Connect(function()
+local function HandleNpcs()
+	local now = os.clock()
+	local npcConfigs = Config.NPC_TYPES
+
+	for i: any in clientOwnerShip do
+		local data = idMap[i]
+		--The client has to atleast received one snapshot before we start sending updates
+		if not data or not data.snapshot:GetLatest() then
+			continue
+		end
+		
+		local tickRate = npcConfigs[data.npcType or "DEFAULT"].TICK_RATE
+		if now - (data.lastSent or 0) < tickRate then
+			continue
+		end
+		data.lastSent = now
+		if not data.character then
+			continue
+		end
+		local char = data.character
+		local primaryPart = char.PrimaryPart
+		if not primaryPart then
+			continue
+		end
+		local currentCFrame = primaryPart.CFrame
+		local changed = checkCFrameChanges(currentCFrame, data.lastCFrame or CFrame.identity)
+		if not changed then
+			continue
+		end
+		data.lastCFrame = currentCFrame
+		table.insert(outgoingSnapshots, {
+			timestamp = os.clock(),
+			cframe = currentCFrame,
+			id = i+1,
+		})
+	end
+end
+local function handleCharacter()
 	if os.clock() - lastSent < (playerTickRates[playerNetworkId] or Config.TICK_RATE) then
 		return
 	end
@@ -378,8 +457,7 @@ RunService.PostSimulation:Connect(function()
 
 	local currentCFrame = primaryPart.CFrame
 
-	local changed = vector.magnitude(lastSentCFrame.Position - currentCFrame.Position :: any) >= 0.05
-		or not lastSentCFrame.Rotation:FuzzyEq(currentCFrame.Rotation :: any, 0.0001)
+	local changed = checkCFrameChanges(currentCFrame, lastSentCFrame)
 
 	lastSentCFrame = currentCFrame
 
@@ -390,7 +468,27 @@ RunService.PostSimulation:Connect(function()
 	table.insert(outgoingSnapshots, {
 		timestamp = os.clock(),
 		cframe = currentCFrame,
+		id = 0
 	})
+end
+local function handleAwaitingSnapshots()
+	local now = os.clock()
+	for id, snapshot in awaitingSnapshots do
+		if now - snapshot.clock < MAX_AWAITING_TIME then
+			if idMap[id] then
+			
+				HandleReplicatedData({ [id] = snapshot.timestamp }, { [id] = snapshot.cframe })
+				awaitingSnapshots[id] = nil
+			end
+		else
+			awaitingSnapshots[id] = nil
+		end
+	end
+end
+RunService.PostSimulation:Connect(function()
+	handleAwaitingSnapshots()
+	handleCharacter()
+	HandleNpcs()
 	Flush()
 end)
 

--- a/src/Server/Replicate.luau
+++ b/src/Server/Replicate.luau
@@ -24,9 +24,15 @@ local ServerReplicateCFrame = Instance.new("UnreliableRemoteEvent")
 ServerReplicateCFrame.Name = "ServerReplicateCFrame"
 ServerReplicateCFrame.Parent = ReplicatedStorage
 
-local new_Players = {}
+local newPlayers = {}
 local idStack = {} :: { number }
 local playerIdMap = {} :: { [Player]: number }
+local clientOwners = {}
+
+task.defer(function()
+	local NpcRegistry = (require)(script.Parent.Parent.Shared.NpcRegistry)
+	clientOwners = NpcRegistry._ClientOwners
+end)
 
 export type ReplicationRule = {
 	filterType: "include" | "exclude",
@@ -42,6 +48,7 @@ local idMap = {} :: {
 		serverOwned: boolean?,
 		npcType: string?,
 		model: Model?,
+		networkOwner: Player?,
 
 		_characterAdded: RBXScriptConnection?,
 		_characterRemoving: RBXScriptConnection?,
@@ -140,8 +147,9 @@ local function GetNextID(): number
 	return IncrementalFactoryUID
 end
 
+local RandomOffset = Random.new()
 local function ReturnID(id: number)
-	table.insert(idStack, id)
+	task.delay(RandomOffset:NextNumber(2,4), table.insert, idStack, id) -- this way we don't immediately reuse ids
 end
 
 local function GetIdFrom(input: Player | Model | number): number?
@@ -243,9 +251,7 @@ end
 Players.PlayerAdded:Connect(function(player: Player)
 	local id = GetNextID()
 	playerIdMap[player] = id
-	task.delay(1, function()
-		table.insert(new_Players, player)
-	end)
+
 	idMap[id] = {
 		player = player,
 		snapshot = Snapshots(CFrame.identity.Lerp),
@@ -326,28 +332,33 @@ Players.PlayerRemoving:Connect(function(player)
 end)
 
 ClientReplicateCFrame.OnServerEvent:Connect(function(player: Player, snapshotBuffer: buffer)
-	local id = playerIdMap[player]
-	if not id then
-		return
-	end
-
-	local data = idMap[id]
-	if not data or not data.snapshot then
-		return
-	end
-
+	local playerId = playerIdMap[player]
 	SNAPSHOT_SIZE = if Config.SEND_FULL_ROTATION then 24 else 20
 
+	local ownedNpcs = clientOwners[player] or {}
 	local offset = 0
 	for i = 1, buffer.len(snapshotBuffer) // SNAPSHOT_SIZE do
 		local snapshot = UnpackSnapshotData(snapshotBuffer, offset)
 		offset += SNAPSHOT_SIZE
+		local id = snapshot.id - 1
+		if id == -1 then
+			id = playerId
+		end
 
+		local data = idMap[id]
+		if not data then
+			continue
+		end
+
+		if id ~= playerId and not ownedNpcs[id] then
+			continue
+		end
 		data.clientLastTick = snapshot.timestamp
 		data.snapshot:Push(snapshot.timestamp, snapshot.cframe)
+
+		lastReplicatedTimes[id] = 0
 	end
 
-	lastReplicatedTimes[id] = 0
 	local character = player.Character
 	local hrp = character and character.PrimaryPart :: BasePart?
 
@@ -447,7 +458,7 @@ RunService.PostSimulation:Connect(function(deltaTime)
 	end
 
 	local allPlayers = {}
-	local hasNewPlayers = #new_Players > 0
+	local hasNewPlayers = #newPlayers > 0
 	for id, data in idMap do
 		local character = data.player and GetCharacter(data.player)
 		local isNPC = data.serverOwned == true
@@ -461,11 +472,13 @@ RunService.PostSimulation:Connect(function(deltaTime)
 		local now = os.clock()
 		local lastReplicated = lastReplicatedTimes[id]
 
-		if now - lastReplicated < tickInterval then
+		local inInterval = now - lastReplicated < tickInterval
+		if inInterval and not hasNewPlayers then
 			continue
 		end
-		lastReplicatedTimes[id] = now
-
+		if not inInterval then
+			lastReplicatedTimes[id] = now
+		end
 		local latestSnapshot = data.snapshot:GetLatest()
 		local cframe = CFrame.identity
 		if latestSnapshot then
@@ -485,12 +498,17 @@ RunService.PostSimulation:Connect(function(deltaTime)
 			character.PrimaryPart.CFrame = cframe
 		end
 
-		if not changed then
+		if not changed or inInterval then
+			
 			if hasNewPlayers then
-				for _, newPlayer in new_Players do
+
+				for _, newPlayer:any in newPlayers do
 					local rule = data.replicationRule
-					if not rule or (rule.filterType == "exclude" and not table.find(rule.filterPlayers, newPlayer))
-						or (rule.filterType == "include" and table.find(rule.filterPlayers, newPlayer)) then
+					if
+						not rule
+						or (rule.filterType == "exclude" and not table.find(rule.filterPlayers, newPlayer))
+						or (rule.filterType == "include" and table.find(rule.filterPlayers, newPlayer))
+					then
 						local list = playerSpecific[newPlayer]
 						if list then
 							local buff = buffer.create(SNAPSHOT_SIZE)
@@ -502,7 +520,8 @@ RunService.PostSimulation:Connect(function(deltaTime)
 			end
 			continue
 		end
-		
+	
+
 		local buff = buffer.create(SNAPSHOT_SIZE)
 		PackSnapshotData(buff, 0, data.clientLastTick or now, cframe, id)
 
@@ -531,7 +550,7 @@ RunService.PostSimulation:Connect(function(deltaTime)
 			end
 		end
 	end
-	new_Players = {}
+	table.clear(newPlayers)
 	debug.profileend()
 	debug.profilebegin("FlushNPCs")
 
@@ -542,6 +561,24 @@ RunService.PostSimulation:Connect(function(deltaTime)
 
 	for player, list in playerSpecific do
 		Flush(list, player)
+	end
+
+	debug.profileend()
+
+	debug.profilebegin("Move Client Npcs")
+
+	for plr,ids:any in clientOwners do
+		for id,_ in ids do
+			local data = idMap[id]
+			if not data or not data.model or not data.model.PrimaryPart then
+				continue
+			end
+
+			local latestSnapshot = data.snapshot:GetLatest()
+			if latestSnapshot then
+				data.model.PrimaryPart.CFrame = latestSnapshot.value
+			end
+		end
 	end
 
 	debug.profileend()
@@ -668,6 +705,7 @@ local function PushNPCTransform(target: number | Model, cframe: CFrame, t: numbe
 end
 
 return {
+	_newPlayers = newPlayers, -- This is needed for NpcRegistry 
 	idMap = idMap,
 	Replicators = replicators,
 

--- a/src/Shared/NpcRegistry.luau
+++ b/src/Shared/NpcRegistry.luau
@@ -1,4 +1,5 @@
 local HttpService = game:GetService("HttpService")
+local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
@@ -26,15 +27,31 @@ local NpcRemoved: Signal.Signal<number, Model> = Signal.new()
 local CAMERA = Instance.new("Camera", workspace)
 CAMERA.Name = "NpcRegistryCamera"
 local NPC_MODEL_CACHE
+local NpcRegistryRemote: RemoteEvent
 
 if IS_SERVER then
+	NpcRegistryRemote = Instance.new("RemoteEvent", script)
+	NpcRegistryRemote.Name = "OwnerChanged"
 	NPC_MODEL_CACHE = Instance.new("Folder", ReplicatedStorage)
 	NPC_MODEL_CACHE.Name = "NPC_MODEL_CACHE"
 elseif IS_CLIENT then
+	NpcRegistryRemote = script:WaitForChild("OwnerChanged") :: RemoteEvent
 	NPC_MODEL_CACHE = ReplicatedStorage:WaitForChild("NPC_MODEL_CACHE") :: any
 end
 
 local NPC_MODELS = Config.NPC_MODELS
+
+local ClientOwners = {} :: { [any]: any }
+
+local function removeOwner(client, id)
+	if not ClientOwners[client] then
+		return
+	end
+	ClientOwners[client][id] = nil
+	if not next(ClientOwners[client]) then
+		ClientOwners[client] = nil
+	end
+end
 
 local function ClientRegister(id, model: Model, data: { type: string, initData: any? })
 	local npcType = data.type
@@ -45,8 +62,8 @@ local function ClientRegister(id, model: Model, data: { type: string, initData: 
 
 	local clone = model:Clone()
 	clone.Name = tostring(id)
-	clone.Parent = CAMERA;
-	(clone.PrimaryPart :: any).Anchored = true
+	clone.Parent = CAMERA
+	--(clone.PrimaryPart :: any).Anchored = true
 
 	Cache[id] = clone
 	clone:PivotTo(CFrame.new(0, 1000000, 0))
@@ -75,7 +92,6 @@ local function Check()
 			)
 			continue
 		end
-
 		ClientRegister(tonumber(id) :: number, npc, data)
 	end
 end
@@ -108,6 +124,9 @@ function Npc.Register(model: Model, npcType: string?, npcModelType: string?, aut
 	local id = ServerReplicate.RegisterNPC(model, npcType)
 	Cache[id] = model
 	model.Parent = folder
+	if model and model.PrimaryPart then
+		ServerReplicate.PushNPCTransform(id, model.PrimaryPart.CFrame, os.clock())
+	end
 
 	pcall(function()
 		(model.PrimaryPart :: any):SetNetworkOwner(nil)
@@ -148,6 +167,11 @@ function Npc.UnRegister(idOrModel: number | Model): Model
 
 	Cache[id] = nil
 	AutomaticNpc[id] = nil
+	local data = ServerReplicate.idMap[id]
+	local owner = data.networkOwner
+
+	removeOwner(owner, id)
+
 	local actualModel = ServerReplicate.UnregisterNPC(id)
 
 	local model = NPC_MODEL_CACHE:FindFirstChild(tostring(id))
@@ -166,41 +190,182 @@ function Npc.GetModel(id: number): Model
 	return Cache[id]
 end
 
-if IS_CLIENT then
-	NPC_MODEL_CACHE.AttributeChanged:Connect(function(attribute)
-		local id = tonumber(attribute)
-		if not id then
+function Npc.SetPosition(id: number, cframe: CFrame)
+	if IS_CLIENT then
+		local model = Cache[id]
+		if model and model.PrimaryPart then
+			model:PivotTo(cframe)
+		end
+	else
+		local data = ServerReplicate.idMap[id]
+		if not data then
 			return
 		end
-		local strData = NPC_MODEL_CACHE:GetAttribute(attribute)
-		if not strData then
-			ClientReplicate.UnregisterNPC(id)
-			local npc = Cache[id]
-			Cache[id] = nil
-			NpcRemoved:Fire(id, npc)
-			npc:Destroy()
-		elseif type(strData) == "string" then
-			local data = HttpService:JSONDecode(strData)
-			local npc = NPC_MODEL_CACHE:FindFirstChild(tostring(id))
-			if data.modelType then
-				npc = NPC_MODELS[data.modelType] or npc
-			end
+		if data.networkOwner then
+			NpcRegistryRemote:FireClient(data.networkOwner,'m', id, cframe)
+			return
+		end
+		local model = Cache[id]
+		if AutomaticNpc[id] and model and model.PrimaryPart then
+			model.PrimaryPart.CFrame = cframe
+		end
+		ServerReplicate.PushNPCTransform(id, cframe, os.clock())
+	end
+	
+end
 
-			if not npc or not npc:IsA("Model") then
-				warn(
-					`Npc cache: Invalid NPC Model for ID: {id} TYPE: {data.modelType} MAKE SURE IT IS REGISTERED AS A MODEL IN CONFIG [Chrono/src/shared/config]`
-				)
+function Npc.SetNetworkOwner(id: number, player: Player?)
+	if IS_CLIENT then
+		error("SetNetworkOwner can only be called on the server.")
+	end
+	local data = ServerReplicate.idMap[id]
+	if not data then
+		warn("Npc cache: SetNetworkOwner failed to find data for ID: " .. id .. " Please Investigate.")
+		return
+	end
+	local existingOwner = data.networkOwner
+	if existingOwner == player then
+		return
+	elseif existingOwner then
+		removeOwner(existingOwner, id)
+
+		NpcRegistryRemote:FireClient(existingOwner, "r", id)
+	end
+	data.networkOwner = player
+	NpcRegistryRemote:FireAllClients("c", id)
+	local idMapData = ServerReplicate.idMap[id]
+	if idMapData then
+		local latest = idMapData.snapshot:GetLatest()
+		idMapData.snapshot:Clear()
+		if latest then
+			idMapData.snapshot:Push(0, latest.value)
+		end
+	end
+	if player then
+		ClientOwners[player] = ClientOwners[player] or {}
+		ClientOwners[player][id] = true
+		NpcRegistryRemote:FireClient(player, "a", id)
+	end
+end
+
+function Npc.GetNetworkOwner(id: number): Player?
+	if IS_CLIENT then
+		error("GetNetworkOwner can only be called on the server.")
+	end
+	local data = ServerReplicate.idMap[id]
+	if not data then
+		return
+	end
+	return data.networkOwner
+end
+
+function Npc.GetNpcsOwnedBy(player: Player): {}?
+	if IS_CLIENT then
+		error("GetNpcsOwnedBy can only be called on the server.")
+	end
+	local arr = {}
+	if ClientOwners[player] then
+		for id in ClientOwners[player] do
+			table.insert(arr, id)
+		end
+	end
+	return arr
+end
+
+function Npc.GetClientOwned()
+	if not IS_CLIENT then
+		error("GetClientOwned can only be called on the client.")
+	end
+	local arr = {}
+	for id in ClientOwners do
+		table.insert(arr, id)
+	end
+	return arr
+end
+
+if IS_CLIENT then
+	task.delay(0.1, function()
+		NPC_MODEL_CACHE.AttributeChanged:Connect(function(attribute)
+			local id = tonumber(attribute)
+			if not id then
 				return
 			end
-			task.defer(ClientRegister, id, npc, data)
-		end
+			local strData = NPC_MODEL_CACHE:GetAttribute(attribute)
+			if not strData then
+				ClientReplicate.UnregisterNPC(id)
+				local npc = Cache[id]
+				Cache[id] = nil
+				NpcRemoved:Fire(id, npc)
+				npc:Destroy()
+			elseif type(strData) == "string" then
+				local data = HttpService:JSONDecode(strData)
+				local npc = NPC_MODEL_CACHE:FindFirstChild(tostring(id))
+				if data.modelType then
+					npc = NPC_MODELS[data.modelType] or npc
+				end
+
+				if not npc or not npc:IsA("Model") then
+					warn(
+						`Npc cache: Invalid NPC Model for ID: {id} TYPE: {data.modelType} MAKE SURE IT IS REGISTERED AS A MODEL IN CONFIG [Chrono/src/shared/config]`
+					)
+					return
+				end
+				task.defer(ClientRegister, id, npc, data)
+			end
+		end)
+		Check()
+		NpcRegistryRemote.OnClientEvent:Connect(function(t, id,cf)
+			
+			if t == "a" then
+				ClientOwners[id] = ClientOwners[id] or true
+			elseif t == "r" then
+				ClientOwners[id] = nil
+			elseif t == "i" then
+				for v, data in id do
+					v = tonumber(v)
+					ClientOwners[v] = data
+
+					local idData = ClientReplicate.idMap[v]
+				
+					if idData and typeof(data) == "CFrame" then
+						idData.snapshot:Push(os.clock(), data)
+					end
+				end
+			elseif t == "c" then
+				local idData = ClientReplicate.idMap[id]
+				if idData then
+					local latest = idData.snapshot:GetLatest()
+					idData.snapshot:Clear()
+					if latest then
+						idData.snapshot:Push(0, latest.value)
+					end
+					ClientReplicate.BufferTracker.Clear(id)
+					
+				end
+			elseif t == "m" then
+				local model = Cache[id]
+				if model and model.PrimaryPart and typeof(cf) == "CFrame" then
+					model.PrimaryPart.CFrame = cf
+				end
+				local idData = ClientReplicate.idMap[id]
+				if not idData then
+					ClientOwners[id] = cf
+					return
+				end
+				idData.snapshot:Push(os.clock(), cf)
+			end
+		end)
+		NpcRegistryRemote:FireServer()
 	end)
-	Check()
 else
 	RunService.PostSimulation:Connect(function(dt)
 		local now = os.clock()
 		debug.profilebegin("Check Npc CFrames")
 		for id, model in AutomaticNpc do
+			local data = ServerReplicate.idMap[id]
+			if not data or data.networkOwner then
+				continue
+			end
 			local primary = model.PrimaryPart
 			if not primary then
 				continue
@@ -210,7 +375,34 @@ else
 		end
 		debug.profileend()
 	end)
+	Players.PlayerAdded:Connect(function(player)
+		NpcRegistryRemote.OnServerEvent:Wait()
+
+		table.insert(ServerReplicate._newPlayers, player) -- Allow the replicate module to setup the player
+		if not ClientOwners[player] then
+			return
+		end
+
+		local npcS = {}
+		for id in ClientOwners[player] do
+			local data = ServerReplicate.idMap[id]
+			npcS[tostring(id)] = true :: any
+			if not data then
+				continue
+			end
+			local latest = data.snapshot:GetLatest()
+			if not latest then
+				continue
+			end
+			npcS[tostring(id)] = latest.value
+		end
+
+		NpcRegistryRemote:FireClient(player :: Player,"i" ,npcS)
+	end)
 end
+
+Npc._AutomaticNpc = AutomaticNpc
+Npc._ClientOwners = ClientOwners
 
 Npc.NpcAdded = NpcAdded.Event
 Npc.NpcRemoved = NpcRemoved.Event

--- a/test/NpcTest.server.luau
+++ b/test/NpcTest.server.luau
@@ -2,9 +2,21 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local NpcRegistry = require(ReplicatedStorage.Packages.chrono.Shared.NpcRegistry)
 
-do
-	return
+local ENABLED = true
+
+if not ENABLED then
+    return
 end
+
+
+local model1 = Instance.new("Model",workspace)
+local part = Instance.new("Part",model1)
+model1.PrimaryPart = part
+part.Size = Vector3.new(2,5,2)
+part.Position = Vector3.new(10,10,10)
+local id2 = NpcRegistry.Register(model1, "DEFAULT",nil, true)
+
+
 
 local player = game:GetService("Players").PlayerAdded:Wait()
 task.wait(1)
@@ -14,4 +26,21 @@ model.Archivable = true
 local clone = model:Clone()
 clone.Parent = workspace
 
-NpcRegistry.Register(clone, "DEFAULT", "TestNPCs", true)
+local id = NpcRegistry.Register(clone, "DEFAULT",nil, true)
+
+NpcRegistry.SetNetworkOwner(id,player)
+
+NpcRegistry.SetPosition(id2, CFrame.new(4,15,0))
+NpcRegistry.SetPosition(id, CFrame.new(0,10,0))
+
+task.wait(4)
+print("Starting Toggle Loop")
+while true do
+	task.wait(4)
+	print('Set Player')
+	NpcRegistry.SetNetworkOwner(id,player)
+	task.wait(4)
+	print('Set Server')
+	NpcRegistry.SetNetworkOwner(id,nil)
+end
+


### PR DESCRIPTION
Added support for clients to simulate NPCS
You can use test/NpcTest to for a basic test.
Changes:
    NpcRegistry: 
          + Added support for clients to simulate npcs FYI player leaving would not clear the OwnerShip
          + SetPosition(), Will move npcs even if client has ownership of the npc if called from the server, otherwise just a wrapper for `PushNPCTransform`. If called from the client just set primarypartcframe
          + SetNetworkOwner(), Server only function. gives a player ownership of an npc
          + GetNetworkOwner(), Server only function, gets the player or nil if owned by server
          +GetNpcsOwnedBy(), Server function. Returns a list of npcs owned by a player
          + GetClientOwned(), Client function. Returns a list of npcs thats owned by the client.
    InterpolationBuffer: 
          + Remove(), removes an Id
          + Clear(), clears data relating to an id
    Replicate: 
          + Improved consisity with issues of Npcs floating in air if registered before player join
        