### PR TITLE
Fix benchmark code

### DIFF
--- a/benchmarks/TestNPC.server.luau
+++ b/benchmarks/TestNPC.server.luau
@@ -19,6 +19,8 @@ local Character = Player.Character or Player.CharacterAdded:Wait()
 Character.Archivable = true
 
 local Chrono = require(ReplicatedStorage.Packages.chrono)
+Chrono.Start()
+
 local NpcRegistry = Chrono.NpcRegistry
 local ServerChrono = Chrono.ChronoServer
 


### PR DESCRIPTION
Added `.Start()` to chronos, otherwise it errors.

I believe you also need to call `.Start()` on the client, but I see no file that currently outlines client benchmark code so I didn't add it.