### PR TITLE
Fix player character initData replication

### DIFF
--- a/src/Shared/Character.luau
+++ b/src/Shared/Character.luau
@@ -69,7 +69,7 @@ function Characters.SetCharacter(player: Player, model: Model | string, data: an
 		clone.Name = tostring(id)
 		clone.Parent = ModelCache
 		if data then
-			ModelCache:SetAttribute("data", HttpService:JSONEncode({ data }))
+			clone:SetAttribute("_chronoInitData", HttpService:JSONEncode({ data }))
 		end
 	end
 
@@ -79,9 +79,9 @@ end
 if IS_CLIENT then
 	local function handleChild(child: Instance)
 		local id = tonumber(child.Name)
-		local data = ModelCache:GetAttribute(child.Name)
+		local data = child:GetAttribute("_chronoInitData")
 		data = data and HttpService:JSONDecode(data)[1]
-		ModelCache:SetAttribute(child.Name, nil)
+		child:SetAttribute("_chronoInitData", nil)
 
 		if not id then
 			child:Destroy()


### PR DESCRIPTION
Receiving clients are expecting initial data, if provided, via an attribute matching the incoming character's name attached to ModelCache, but the server is writing to "data" instead.

After correcting the mismatch, reading/writing to clone.Name/child.Name would still be insufficient, as subsequent calls to Character.SetCharacter() can potentially write identical data, skipping replication. The client then reads nil since its copy of the field is still nil from the last receive.

With the above in mind, we write an attribute directly to the character and clear it locally when we're finished with it.