### PR TITLE
Support for runtime buffer change

### DIFF
--- a/docs/getting-started/configurations.md
+++ b/docs/getting-started/configurations.md
@@ -160,6 +160,12 @@ local ENTITY_TYPES = {
 
 * `BUFFER` - The buffer time for the npc. If buffer is set to 0 or nil then the entity will use an dynamic buffer (entities that are client owned will automatically use a dynamic buffer. This will only apply to server owned entities). 
 
+!!! info "Changing the buffer at runtime (client)"
+    - **Per entity:** `Entity.SetClockBuffer(entity, seconds)` overrides a single entity's buffer.
+    - **Per entity type:** `Config._GetEntityType(name):UpdateBuffer(seconds)` updates every entity of that type (shared clocks and owned per-entity clocks), except entities that set their own `SetClockBuffer` override.
+
+    Pass `0` for a dynamic buffer.
+
 * `TICK_RATE` - How often the entity replicates per second.
 * `FULL_ROTATION` - Whether to replicate full rotation or just yaw. Default is false (yaw only).
 * `MODEL_REPLICATION_MODE` - Overrides the default model replication mode for this entity type.

--- a/docs/getting-started/configurations.md
+++ b/docs/getting-started/configurations.md
@@ -162,7 +162,7 @@ local ENTITY_TYPES = {
 
 !!! info "Changing the buffer at runtime (client)"
     - **Per entity:** `Entity.SetClockBuffer(entity, seconds)` overrides a single entity's buffer.
-    - **Per entity type:** `Config._GetEntityType(name):UpdateBuffer(seconds)` updates every entity of that type (shared clocks and owned per-entity clocks), except entities that set their own `SetClockBuffer` override.
+    - **Per entity type:** `Config.GetEntityType(name):UpdateBuffer(seconds)` updates every entity of that type (shared clocks and owned per-entity clocks), except entities that set their own `SetClockBuffer` override.
 
     Pass `0` for a dynamic buffer.
 

--- a/docs/reference/entity.md
+++ b/docs/reference/entity.md
@@ -68,6 +68,18 @@ Sets the entity type configuration for this entity.
 
 - `entityConfig` - The entity type name to use for this entity.
 
+### `SetClockBuffer(self: Entity, buffer: number?) -> ()`
+
+!!! Warning "Client Only"
+    Calling this on the server errors.
+
+Sets a per-entity interpolation buffer, creating a dedicated client clock for this entity. This overrides the entity config's `BUFFER` and is not affected by later `config:UpdateBuffer` changes.
+
+- `buffer` - The buffer time in seconds. Pass `0` (or a negative value) for a dynamic buffer. Pass `nil` to clear the override and fall back to the entity config's buffer.
+
+!!! note
+    Intended for client-owned entities. To change the buffer for server-owned entities, use `config:UpdateBuffer` (per type) instead.
+
 ### `SetBroadPhase(self: Entity, broadPhase: Vector3?) -> ()`
 
 Sets the broadphase size for this entity used for culling. If nil, unsets broad

--- a/src/Client/ClientClock.luau
+++ b/src/Client/ClientClock.luau
@@ -119,7 +119,25 @@ const function Update(clientClock: Types.ClientClock, dt: number)
 	clientClock.renderAt = renderAt
 end
 
+const function UpdateBuffer(clientClock: Types.ClientClock, buffer: number?)
+	buffer = if buffer and buffer <= 0 then nil else buffer
+	const currentBuffer = clientClock.bufferConst
+	if currentBuffer == buffer then
+		return
+	end
+	if not buffer then
+		if not clientClock.buffer then
+			clientClock.buffer = BufferTracker.new(clientClock)
+		end
+	else
+		clientClock.buffer = nil
+	end
+	clientClock.bufferConst = buffer
+	clientClock.renderAt = nil
+end
+
 const function new(tickRate: number, name: string, bufferNumber: number?, networkOwner: Player?): Types.ClientClock
+	bufferNumber = if bufferNumber and bufferNumber <= 0 then nil else bufferNumber
 	const self: Types.ClientClock = {
 		name = name,
 		lastClockAt = nil,
@@ -137,6 +155,7 @@ const function new(tickRate: number, name: string, bufferNumber: number?, networ
 		GetTargetRenderTime = GetTargetRenderTime,
 		Clear = Clear,
 		SetTickRate = SetTickRate,
+		UpdateBuffer = UpdateBuffer,
 		Destroy = Destroy,
 	}
 	if not bufferNumber then

--- a/src/Shared/Config.luau
+++ b/src/Shared/Config.luau
@@ -249,10 +249,10 @@ return {
 	},
 
 	_EntityConfigs = ENTITY_TYPES,
-	_GetEntityType = GetEntityType,
+	_GetEntityType = GetEntityType, --// For internal use only
+	GetEntityType = GetEntityType,
 	_GetEntityModel = GetEntityModel,
-	_GetConfig = GetConfig, -- keeping for backwards compatibility, but use GetConfig instead
-	GetConfig = GetConfig,
+	_GetConfig = GetConfig,
 	_Lock = Lock,
 	_WaitForLock = WaitForLock,
 	_GetBroadPhase = GetBroadPhase,

--- a/src/Shared/Config.luau
+++ b/src/Shared/Config.luau
@@ -205,9 +205,31 @@ const function Lock()
 			cloned.TICKER = (require)(script.Parent.Ticker).new(cloned)
 		else
 			cloned.CLIENT_CLOCK = {} :: any
+			cloned.UpdateBuffer = function(self, buffer: number)
+				if not self.CLIENT_CLOCK or not next(self.CLIENT_CLOCK :: any) then
+					error("Config not initialized yet, cannot update buffer for entity type: " .. self.NAME)
+				end
+				self.BUFFER = buffer
+				if self.CLIENT_CLOCK.NORMAL then
+					self.CLIENT_CLOCK.NORMAL:UpdateBuffer(buffer)
+				end
+				if self.CLIENT_CLOCK.HALF then
+					self.CLIENT_CLOCK.HALF:UpdateBuffer(buffer)
+				end
+
+				-- Owned entities of this type use their own per-entity clock, so update those too.
+				-- Skip any entity that set an explicit per-entity override (_clockBuffer), which wins over the config.
+				const Holder = (require)(script.Parent.Holder)
+				const Entity = (require)(script.Parent.Entity)
+				for _, entity in Holder.idMap do
+					if entity.entityConfig == self then
+						Entity._UpdateClockBuffer(entity)
+					end
+				end
+			end
 		end
 
-		ENTITY_TYPES[i] = table.freeze(cloned)
+		ENTITY_TYPES[i] = cloned
 	end
 	for _, fx in waiting do
 		fx()
@@ -229,7 +251,8 @@ return {
 	_EntityConfigs = ENTITY_TYPES,
 	_GetEntityType = GetEntityType,
 	_GetEntityModel = GetEntityModel,
-	_GetConfig = GetConfig,
+	_GetConfig = GetConfig, -- keeping for backwards compatibility, but use GetConfig instead
+	GetConfig = GetConfig,
 	_Lock = Lock,
 	_WaitForLock = WaitForLock,
 	_GetBroadPhase = GetBroadPhase,

--- a/src/Shared/Entity.luau
+++ b/src/Shared/Entity.luau
@@ -197,6 +197,30 @@ const function FireEvent(entity: Entity, eventName: string, ...: any)
 	end
 end
 
+-- If buffer is given then it will create a client clock for the entity as well.
+const function SetClock(self: Entity, buffer: number | false?)
+	if self._clientClock then
+		self._clientClock:Destroy()
+		self._clientClock = nil
+	end
+	if buffer == false then
+		self._clockBuffer = nil
+		buffer = nil
+	end
+	buffer = buffer or self._clockBuffer
+	self._clockBuffer = buffer
+	const entityBuffer = buffer or self.entityConfig.BUFFER or 0
+	if self.networkOwner or buffer then
+		const networkOwner = self.networkOwner
+		self._clientClock = ClientClock.new(
+			self.entityConfig.TICK_RATE,
+			`Entity id: {self.id} plr: {networkOwner and networkOwner.Name or "SERVER"}`,
+			entityBuffer,
+			networkOwner
+		)
+	end
+end
+
 const function CheckNetworkOwner(self: Entity, prev: Player?)
 	self.isContextOwner = self.networkOwner == LOCAL_PLAYER
 	const isSameOwner = self.networkOwner == prev
@@ -252,20 +276,7 @@ const function CheckNetworkOwner(self: Entity, prev: Player?)
 	end
 
 	if not IS_SERVER then
-		if self._clientClock then
-			self._clientClock:Destroy()
-			self._clientClock = nil
-		end
-		const entityBuffer = self.entityConfig.BUFFER
-		if self.networkOwner or (entityBuffer <= 0 or not entityBuffer) then
-			const networkOwner = self.networkOwner
-			self._clientClock = ClientClock.new(
-				self.entityConfig.TICK_RATE,
-				`Entity id: {self.id} plr: {networkOwner and networkOwner.Name or "SERVER"}`,
-				nil,
-				networkOwner
-			)
-		end
+		SetClock(self)
 	end
 
 	FireEvent(self, "NetworkOwnerChanged", self.networkOwner, prev)
@@ -531,6 +542,21 @@ function Entity.SetConfig(self: Entity, entityConfig: string)
 		config = Config._GetEntityType("DEFAULT")
 	end
 	SetValue(self, "entityConfig", config, false, config.NAME)
+	if not IS_SERVER then
+		SetClock(self)
+	end
+end
+
+--[=[
+	Sets the client clock buffer for the entity. 
+
+	@param buffer? The buffer to set for the client clock. If nil, will use the entity config's buffer. 
+]=]
+function Entity.SetClockBuffer(self: Entity, buffer: number?)
+	if IS_SERVER then
+		error("SetClockBuffer can only be called on the client")
+	end
+	SetClock(self, buffer ~= nil and buffer or false)
 end
 
 --[=[
@@ -986,4 +1012,5 @@ Entity._SetPartCFrame = SetPartCFrame
 Entity._GetRootPart = GetRootPart
 Entity._LockPartPhysicsReplication = LockCFReplication
 Entity._UnlockPartPhysicsReplication = UnlockCFReplication
+Entity._UpdateClockBuffer = SetClock
 return Entity

--- a/src/Shared/Types.luau
+++ b/src/Shared/Types.luau
@@ -107,6 +107,7 @@ export type EntityConfig = {
 	CUSTOM_INTERPOLATION: boolean?,
 	ASSEMBLY_ROOT_PART_CHECK: boolean?,
 	ATTACH_MODEL_META_DATA: boolean?, -- defaults to true
+	UpdateBuffer: (self: EntityConfig, buffer: number) -> ()?,
 }
 
 export type EntityConfigInput = {
@@ -163,6 +164,7 @@ export type ClientClock = {
 	OnSnapShot: (self: ClientClock, currentTime: number) -> (),
 	Refresh: (self: ClientClock, currentTime: number) -> boolean,
 	SetTickRate: (self: ClientClock, tickRate: number) -> (),
+	UpdateBuffer: (self: ClientClock, time: number?) -> (),
 	Destroy: (self: ClientClock) -> (),
 }
 
@@ -189,6 +191,7 @@ export type EntityReceivePacket = {
 export type Entity = {
 	--Client
 	-- this is for non server owned
+	_clockBuffer: number?,
 	_clientClock: ClientClock?,
 	_modelMetaData: string?,
 	broadPhase: vector?,


### PR DESCRIPTION
Added 2 new apis for changing buffer at runtime.

For changing a single entity this can be called via `Entity.SetClockBuffer` and for changing for a whole type use `Config.GetEntityType(name):UpdateBuffer(seconds)`